### PR TITLE
Reuse relay connection

### DIFF
--- a/nostr.go
+++ b/nostr.go
@@ -43,7 +43,7 @@ type RelayConnection struct {
 var relayConnections = make(map[string]*RelayConnection)
 var relayConnectionsMutex sync.Mutex
 var connectionTimeout = 30 * time.Minute
-var ignoreRelayDuration = 10 * time.Minute
+var ignoreRelayDuration = 5 * time.Minute
 var ignoredRelays = make(map[string]time.Time)
 var ignoredRelaysMutex sync.Mutex
 
@@ -309,6 +309,7 @@ func publishNostrEvent(ev nostr.Event, relays []string) {
 			ctx := context.WithValue(context.Background(), "url", url)
 			status, err := relay.Publish(ctx, ev)
 			if err != nil {
+				ignoreRelay(url)
 				log.Printf("Error publishing to relay %s: %v", url, err)
 			} else {
 				log.Printf("[NOSTR] published to %s: %s", url, status)


### PR DESCRIPTION
Improve how we connect to Nostr relays:
- Keep connection open for 30 minutes
- Ignore relays that we couldn't connect to (5 minutes timeout)
- Reuse connection to publish zap events.